### PR TITLE
Fix Makefile to install pip in venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ install-dev: venv
 
 venv:
 	python -m venv $(VENV)
+	$(VENV)/bin/python -m ensurepip --upgrade
+	$(VENV)/bin/python -m pip install --upgrade pip
 	$(INSTALLER) requirements.txt
 	$(INSTALLER) requirements-dev.txt
 


### PR DESCRIPTION
## Summary
- ensure `make venv` installs pip before installing requirements

## Testing
- `make test` *(fails: could not download packages)*

------
https://chatgpt.com/codex/tasks/task_e_685c442632e8832998251a15307e1326